### PR TITLE
Add Item constructor that doesn't require an ID to be provided

### DIFF
--- a/BiscuitCaseApp/src/main/java/me/noahandrews/biscuitcaseapp/Item.java
+++ b/BiscuitCaseApp/src/main/java/me/noahandrews/biscuitcaseapp/Item.java
@@ -26,6 +26,14 @@ public class Item implements Serializable {
         this.quantityAvailable = quantityAvailable;
     }
 
+    public Item(String name, double price, Category category, boolean hasLimitedQuantity, @Nullable int quantityAvailable) {
+        this.name = name;
+        this.price = price;
+        this.category = category;
+        this.hasLimitedQuantity = hasLimitedQuantity;
+        this.quantityAvailable = quantityAvailable;
+    }
+
     //Copy constructor
     public Item(Item original) {
         this.id = original.id;


### PR DESCRIPTION
This will be needed when Items are created in the management app. Closes #9.
